### PR TITLE
Add exporting and loading scripts

### DIFF
--- a/scripts/export
+++ b/scripts/export
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+# Variables =======================================================================================
+
+# User-set variables. None should have spaces!
+bin_dir="/home/accts/aas85/Workspace/cs438/final-project/geph-build/bin"
+data_sets_dir="/tmp/cs438-afc33-aas85/data-sets"
+db="mygraph1"
+tables=("nodes" "edges")
+
+# Constructed variables
+pg_dump="$bin_dir/pg_dump"
+psql="$bin_dir/psql"
+
+# Helper functions ================================================================================
+
+pg_dump_export()
+{
+    output_name=$1
+    format_flag=$2
+    compression_flag=$3
+
+    output_path="$data_sets_dir/$db/$db-$output_name"
+    echo "Exporting $export_type..."
+
+    ( time $pg_dump -f "$output_path.export" $format_flag $compression_flag $db ) 2> \
+                       "$output_path.time"
+}
+
+copy_export()
+{
+    output_name=$1
+    format=$2
+
+    output_path="$data_sets_dir/$db/$db-$output_name"
+    echo "Exporting $output_name..."
+
+    ( time $psql -c "COPY $table TO '$output_path.export' WITH (FORMAT $format)" $db ) 2> \
+                                    "$output_path.time"
+}
+
+# Main script =====================================================================================
+
+mkdir "$data_sets_dir/$db"
+
+# Run pg_dump exports
+pg_dump_export "full-plain"                  "-Fp"
+pg_dump_export "full-custom-uncompressed"    "-Fc" "-Z0"
+pg_dump_export "full-custom-compressed"      "-Fc" "-Z9"
+pg_dump_export "full-directory-uncompressed" "-Fd" "-Z0"
+pg_dump_export "full-directory-compressed"   "-Fd" "-Z9"
+pg_dump_export "full-tar"                    "-Ft"
+
+# Run COPY exports
+for table in "${tables[@]}"; do
+    copy_export "$table-text"   "text"
+    copy_export "$table-csv"    "csv"
+    copy_export "$table-binary" "binary"
+done
+
+# Clean up
+if [[ -f "gmon.out" ]]; then
+    rm "gmon.out"
+fi

--- a/scripts/tests/full-db-test
+++ b/scripts/tests/full-db-test
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+source "./loading-and-profiling-lib.sh"
+mkdir "$data_collection_dir/$db"
+
+# Plain
+
+clean_up "full"
+psql_load "full-plain"
+profile "full-plain" $psql
+
+# Custom, uncompressed
+
+clean_up "full"
+pg_restore_load "full-custom-uncompressed" "full-custom-uncompressed-serial" "-Fc" "-j1"
+profile "full-custom-uncompressed-serial" $pg_restore
+
+clean_up "full"
+pg_restore_load "full-custom-uncompressed" "full-custom-uncompressed-parallel" "-Fc" "-j8"
+profile "full-custom-uncompressed-parallel" $pg_restore
+
+# Custom, compressed
+
+clean_up "full"
+pg_restore_load "full-custom-compressed" "full-custom-compressed-serial" "-Fc" "-j1"
+profile "full-custom-compressed-serial" $pg_restore
+
+clean_up "full"
+pg_restore_load "full-custom-compressed" "full-custom-compressed-parallel" "-Fc" "-j8"
+profile "full-custom-compressed-parallel" $pg_restore
+
+# Directory, uncompressed
+
+clean_up "full"
+pg_restore_load "full-directory-uncompressed" "full-directory-uncompressed-serial" "-Fd" "-j1"
+profile "full-directory-uncompressed-serial" $pg_restore
+
+clean_up "full"
+pg_restore_load "full-directory-uncompressed" "full-directory-uncompressed-parallel" "-Fd" "-j8"
+profile "full-directory-uncompressed-parallel" $pg_restore
+
+# Directory, compressed
+
+clean_up "full"
+pg_restore_load "full-directory-compressed" "full-directory-compressed-serial" "-Fd" "-j1"
+profile "full-directory-compressed-serial" $pg_restore
+
+clean_up "full"
+pg_restore_load "full-directory-compressed" "full-directory-compressed-parallel" "-Fd" "-j8"
+profile "full-directory-compressed-parallel" $pg_restore
+
+# Tar
+
+clean_up "full"
+pg_restore_load "full-tar" "full-tar-serial" "-Ft" "-j1"
+profile "full-tar-serial" $pg_restore
+
+clean_up

--- a/scripts/tests/index-test
+++ b/scripts/tests/index-test
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+source "./loading-and-profiling-lib.sh"
+mkdir "$data_collection_dir/$db"
+
+for table in "${tables[@]}"; do
+    # Setup indexes after loading data
+    clean_up "full"
+    execute_sql "./sql/setup-$table-table.sql"
+    clean_up
+    copy_load "$table-text" "$table-text-backend-indexes-after-1" "backend" "text"
+    profile "$table-text-backend-indexes-after-1" $psql
+    clean_up
+    execute_sql_and_save "./sql/add-$table-indexes.sql" "$table-text-backend-indexes-after-2"
+    profile "$table-text-backend-indexes-after-2" $psql
+
+    # Setup indexes before loading data
+    clean_up $table
+    copy_load "$table-text" "$table-text-backend-indexes-before" "backend" "text"
+    profile "$table-text-backend-indexes-before" $psql
+done
+
+clean_up

--- a/scripts/tests/loading-and-profiling-lib.sh
+++ b/scripts/tests/loading-and-profiling-lib.sh
@@ -1,0 +1,144 @@
+# filename: loading-and-profiling-lib.sh
+#
+# This file contains various functions for loading and profiling scripts.
+
+# Variables =======================================================================================
+
+# User-set variables. None should have spaces!
+bin_dir="/home/accts/aas85/Workspace/cs438/final-project/geph-build/bin"
+gprof_dir="/home/accts/aas85/Workspace/cs438/final-project/geph-build/data/gprof"
+data_collection_dir="/tmp/cs438-afc33-aas85/data-collection"
+data_sets_dir="/tmp/cs438-afc33-aas85/data-sets"
+db="mygraph1"
+tables=("nodes" "edges")
+
+# Constructed variables
+create_db="$bin_dir/createdb"
+drop_db="$bin_dir/dropdb"
+pg_restore="$bin_dir/pg_restore"
+postgres="$bin_dir/postgres"
+psql="$bin_dir/psql"
+start_dir=$(pwd)
+
+# Functions =======================================================================================
+
+clean_up()
+{
+    mode=$1
+
+    # Drop entire database if full-database mode
+    if [[ $mode == "full" ]]; then
+        $drop_db $db
+        $create_db $db
+
+    # Delete all entries in table if individual-table mode
+    else if [[ ${tables[@]} =~ $mode ]] && [[ $mode != "" ]]; then
+        $psql -c "TRUNCATE $mode RESTART IDENTITY" $db
+    fi
+    fi
+
+    # Remove client gmon.out (if any)
+    if [[ -f "gmon.out" ]]; then
+        rm "gmon.out"
+    fi
+
+    # Remove server gmon.outs (if any)
+    cd $gprof_dir
+    if [[ $(ls .) ]]; then
+        rm -r *
+    fi
+    cd $start_dir
+}
+
+psql_load()
+{
+    input_name=$1
+    output_name=$1
+
+    input_path="$data_sets_dir/$db/$db-$input_name.export"
+
+    execute_sql_and_save $input_path $output_name
+}
+
+execute_sql_and_save()
+{
+    input_path=$1
+    output_name=$2
+
+    output_path="$data_collection_dir/$db/$db-$output_name.time"
+
+    execute_sql $input_path $output_path
+}
+
+execute_sql()
+{
+    input_path=$1
+    output_path=$2
+
+    if [[ $output_path == "" ]]; then
+        $psql $db < $input_path
+    else
+        ( time $psql $db < $input_path ) 2> $output_path
+    fi
+}
+
+pg_restore_load()
+{
+    input_name=$1
+    output_name=$2
+    format_flag=$3
+    job_flag=$4
+
+    input_path="$data_sets_dir/$db/$db-$input_name.export"
+    output_path="$data_collection_dir/$db/$db-$output_name.time"
+
+    ( time $pg_restore -d $db $format_flag $job_flag $input_path ) 2> $output_path
+}
+
+copy_load()
+{
+    input_name=$1
+    output_name=$2
+    frontend_or_backend=$3
+    format=$4
+
+    input_path="$data_sets_dir/$db/$db-$input_name.export"
+    output_path="$data_collection_dir/$db/$db-$output_name.time"
+    cmd=""
+    if      [[ $frontend_or_backend == "frontend" ]]; then cmd="\COPY"
+    else if [[ $frontend_or_backend == "backend"  ]]; then cmd="COPY"
+    fi
+    fi
+
+    ( time $psql -c "$cmd $table FROM '$input_path' WITH (FORMAT $format)" $db ) 2> \
+                                      "$output_path"
+}
+
+profile()
+{
+    output_name=$1
+    binary=$2
+
+    output_path="$data_collection_dir/$db/$db-$output_name.profile"
+
+    mkdir "$output_path"
+    
+    # Store and process client gmon.out
+    mkdir "$output_path/client"
+    if [[ -f "gmon.out" ]]; then
+        cp "gmon.out" "$output_path/client/gmon.out"
+        gprof $binary "$output_path/client/gmon.out" > "$output_path/client/analysis"
+    fi
+    
+    # Store and process server gmon.outs
+    mkdir "$output_path/server"
+    cd $gprof_dir
+    if [[ $(ls .) ]]; then
+        cp -r * "$output_path/server"
+    fi
+    cd "$output_path/server"
+    for dir in $(ls); do
+        gprof $postgres "$dir/gmon.out" > "$dir/analysis" 
+    done
+    cd $start_dir
+}

--- a/scripts/tests/restore-db
+++ b/scripts/tests/restore-db
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+source "./loading-and-profiling-lib.sh"
+
+clean_up "full"
+psql_load "full-plain"
+
+clean_up

--- a/scripts/tests/sql/add-edges-indexes.sql
+++ b/scripts/tests/sql/add-edges-indexes.sql
@@ -1,0 +1,2 @@
+ALTER TABLE ONLY edges
+    ADD CONSTRAINT edges_pkey PRIMARY KEY (node_1, node_2);

--- a/scripts/tests/sql/add-nodes-indexes.sql
+++ b/scripts/tests/sql/add-nodes-indexes.sql
@@ -1,0 +1,5 @@
+ALTER TABLE ONLY nodes
+    ADD CONSTRAINT nodes_email_password_key UNIQUE (email, password);
+
+ALTER TABLE ONLY nodes
+    ADD CONSTRAINT nodes_pkey PRIMARY KEY (id);

--- a/scripts/tests/sql/setup-edges-table.sql
+++ b/scripts/tests/sql/setup-edges-table.sql
@@ -1,0 +1,5 @@
+CREATE TABLE edges (
+    node_1 integer NOT NULL,
+    node_2 integer NOT NULL,
+    "timestamp" timestamp without time zone
+);

--- a/scripts/tests/sql/setup-nodes-table.sql
+++ b/scripts/tests/sql/setup-nodes-table.sql
@@ -1,0 +1,20 @@
+CREATE TABLE nodes (
+    id integer NOT NULL,
+    first_name character varying(50) NOT NULL,
+    last_name character varying(50) NOT NULL,
+    email character varying(50) NOT NULL,
+    password character varying(50) NOT NULL,
+    birthday date NOT NULL,
+    bio character varying(250)
+);
+
+CREATE SEQUENCE nodes_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+ALTER SEQUENCE nodes_id_seq OWNED BY nodes.id;
+ALTER TABLE ONLY nodes ALTER COLUMN id SET DEFAULT nextval('nodes_id_seq'::regclass);
+SELECT pg_catalog.setval('nodes_id_seq', 1000001, true);

--- a/scripts/tests/table-test
+++ b/scripts/tests/table-test
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+source "./loading-and-profiling-lib.sh"
+mkdir "$data_collection_dir/$db"
+
+for table in "${tables[@]}"; do
+    # Frontend copy
+
+    clean_up $table 
+    copy_load "$table-text" "$table-text-frontend" "frontend" "text"
+    profile "$table-text-frontend" $psql
+
+    clean_up $table
+    copy_load "$table-csv" "$table-csv-frontend" "frontend" "csv"
+    profile "$table-csv-frontend" $psql
+
+    clean_up $table
+    copy_load "$table-binary" "$table-binary-frontend" "frontend" "binary"
+    profile "$table-binary-frontend" $psql
+
+    # Backend copy
+
+    clean_up $table
+    copy_load "$table-text" "$table-text-backend" "backend" "text"
+    profile "$table-text-backend" $psql
+
+    clean_up $table
+    copy_load "$table-csv" "$table-csv-backend" "backend" "csv"
+    profile "$table-csv-backend" $psql
+
+    clean_up $table
+    copy_load "$table-binary" "$table-binary-backend" "backend" "binary"
+    profile "$table-binary-backend" $psql
+done
+
+clean_up


### PR DESCRIPTION
Added 2 scripts to help us with our data collection. The first exports a database by various means, and the second profiles various db-loading methods. The latter script stores 1) timing data, 2) analyzed client gmon.outs, and 3) analyzed server gmon.outs. This 3rd piece is super important! It'll lead us to bottlenecks in the Postgres backend.

The second script is intended to be run after the first. It makes several assumptions about where exported dbs are stored in the file system and how they're named, based entirely on the workings of the first script.

I'm currently running the second script on Giraffe. Although I'll probably have to make a few tweaks before it can run to completion.

![image](https://cloud.githubusercontent.com/assets/12616928/14769996/0d9326fe-0a34-11e6-8bec-b29e626f81ad.png)
